### PR TITLE
refactor: all functions take optional ErrorCode now

### DIFF
--- a/StrapperNet/include/strapper/net/SystemContext.h
+++ b/StrapperNet/include/strapper/net/SystemContext.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
 
 namespace strapper { namespace net {
 

--- a/StrapperNet/include/strapper/net/TcpListener.h
+++ b/StrapperNet/include/strapper/net/TcpListener.h
@@ -31,8 +31,7 @@ class TcpListener
 {
 public:
     TcpListener() = default;
-    explicit TcpListener(uint16_t port);
-    TcpListener(uint16_t port, ErrorCode* ec);
+    explicit TcpListener(uint16_t port, ErrorCode* ec = nullptr);
     TcpListener(TcpListener const&) = delete;
     TcpListener(TcpListener&& other) noexcept;
     TcpListener& operator=(TcpListener const&) = delete;
@@ -44,8 +43,7 @@ public:
     bool IsListening() const;
 
     void Close() noexcept;
-    TcpSocket Accept();
-    TcpSocket Accept(ErrorCode* ec);
+    TcpSocket Accept(ErrorCode* ec = nullptr);
 
     explicit operator bool() const;
 
@@ -57,6 +55,8 @@ private:
         SHUTTING_DOWN,
         CLOSED
     };
+
+    TcpSocket accept();
 
     mutable std::mutex m_lock;
     std::condition_variable m_acceptCancel;

--- a/StrapperNet/include/strapper/net/TcpSerializer.h
+++ b/StrapperNet/include/strapper/net/TcpSerializer.h
@@ -26,24 +26,24 @@ namespace strapper { namespace net {
 class TcpSerializer
 {
 public:
-    static constexpr int MAX_STRING_LEN = 1024 * 1024;
+    static constexpr int c_maxStringLen = 1024 * 1024;
 
     explicit TcpSerializer(TcpSocket&& socket);
 
     TcpSocket const& Socket() const;
     TcpSocket& Socket();
 
-    void Write(char c);
-    void Write(bool b);
-    void Write(int32_t int32);
-    void Write(double d);
-    void Write(std::string const& s);
+    void Write(char c, ErrorCode* ec = nullptr);
+    void Write(bool b, ErrorCode* ec = nullptr);
+    void Write(int32_t int32, ErrorCode* ec = nullptr);
+    void Write(double d, ErrorCode* ec = nullptr);
+    void Write(std::string const& s, ErrorCode* ec = nullptr);
 
-    bool Read(char* dest);
-    bool Read(bool* dest);
-    bool Read(int32_t* dest);
-    bool Read(double* dest);
-    bool Read(std::string* dest);
+    bool Read(char* dest, ErrorCode* ec = nullptr);
+    bool Read(bool* dest, ErrorCode* ec = nullptr);
+    bool Read(int32_t* dest, ErrorCode* ec = nullptr);
+    bool Read(double* dest, ErrorCode* ec = nullptr);
+    bool Read(std::string* dest, ErrorCode* ec = nullptr);
 
 private:
     TcpSocket m_socket;

--- a/StrapperNet/include/strapper/net/TcpSocket.h
+++ b/StrapperNet/include/strapper/net/TcpSocket.h
@@ -31,8 +31,7 @@ class TcpSocket
 {
 public:
     TcpSocket() = default;
-    TcpSocket(std::string const& host, uint16_t port);
-    TcpSocket(std::string const& host, uint16_t port, ErrorCode* ec);
+    TcpSocket(std::string const& host, uint16_t port, ErrorCode* ec = nullptr);
     TcpSocket(TcpSocket const&) = delete;
     TcpSocket(TcpSocket&& other) noexcept;
     TcpSocket& operator=(TcpSocket const&) = delete;
@@ -42,21 +41,16 @@ public:
     friend void swap(TcpSocket& left, TcpSocket& right);
 
     bool IsConnected() const;
-    void SetReadTimeout(unsigned milliseconds);
-    void SetReadTimeout(unsigned milliseconds, ErrorCode* ec);
+    void SetReadTimeout(unsigned milliseconds, ErrorCode* ec = nullptr);
 
-    void ShutdownSend();
-    void ShutdownSend(ErrorCode* ec);
+    void ShutdownSend(ErrorCode* ec = nullptr);
     void ShutdownBoth();
     void Close() noexcept;
 
-    void Write(void const* src, size_t len);
-    void Write(void const* src, size_t len, ErrorCode* ec);
-    bool Read(void* dest, size_t len);
-    bool Read(void* dest, size_t len, ErrorCode* ec);
+    void Write(void const* src, size_t len, ErrorCode* ec = nullptr);
+    bool Read(void* dest, size_t len, ErrorCode* ec = nullptr);
 
-    unsigned DataAvailable();
-    unsigned DataAvailable(ErrorCode* ec);
+    unsigned DataAvailable(ErrorCode* ec = nullptr);
 
     explicit operator bool() const;
 
@@ -76,6 +70,8 @@ private:
     };
 
     explicit TcpSocket(TcpBasicSocket&& socket);
+
+    bool read(void* dest, size_t len);
 
     mutable std::mutex m_socketLock;
     std::condition_variable m_readCancel;

--- a/StrapperNet/include/strapper/net/UdpSocket.h
+++ b/StrapperNet/include/strapper/net/UdpSocket.h
@@ -30,8 +30,7 @@ class UdpSocket
 {
 public:
     UdpSocket() = default;
-    explicit UdpSocket(uint16_t myport);
-    UdpSocket(uint16_t myport, ErrorCode* ec);
+    explicit UdpSocket(uint16_t myport, ErrorCode* ec = nullptr);
     UdpSocket(UdpSocket const&) = delete;
     UdpSocket(UdpSocket&& other) noexcept;
     UdpSocket& operator=(UdpSocket const&) = delete;
@@ -41,18 +40,14 @@ public:
     friend void swap(UdpSocket& left, UdpSocket& right);
 
     bool IsOpen() const;
-    void SetReadTimeout(unsigned milliseconds);
-    void SetReadTimeout(unsigned milliseconds, ErrorCode* ec);
+    void SetReadTimeout(unsigned milliseconds, ErrorCode* ec = nullptr);
 
     void Close() noexcept;
 
-    void Write(void const* src, size_t len, IpAddressV4 const& ipAddress, uint16_t port);
-    void Write(void const* src, size_t len, IpAddressV4 const& ipAddress, uint16_t port, ErrorCode* ec);
-    unsigned Read(void* dest, size_t maxlen, IpAddressV4* out_ipAddress, uint16_t* out_port);
-    unsigned Read(void* dest, size_t maxlen, IpAddressV4* out_ipAddress, uint16_t* out_port, ErrorCode* ec);
+    void Write(void const* src, size_t len, IpAddressV4 const& ipAddress, uint16_t port, ErrorCode* ec = nullptr);
+    unsigned Read(void* dest, size_t maxlen, IpAddressV4* out_ipAddress, uint16_t* out_port, ErrorCode* ec = nullptr);
 
-    unsigned DataAvailable() const;
-    unsigned DataAvailable(ErrorCode* ec) const;
+    unsigned DataAvailable(ErrorCode* ec = nullptr) const;
 
     explicit operator bool() const;
 
@@ -64,6 +59,8 @@ private:
         SHUTTING_DOWN,
         CLOSED
     };
+
+    unsigned read(void* dest, size_t maxlen, IpAddressV4* out_ipAddress, uint16_t* out_port);
 
     mutable std::mutex m_socketLock;
     std::condition_variable m_readCancel;

--- a/StrapperNet/lib/linux/ErrorCode.cpp
+++ b/StrapperNet/lib/linux/ErrorCode.cpp
@@ -22,7 +22,6 @@
 #include <sys/socket.h>
 
 #include <cassert>
-#include <string>
 
 namespace strapper { namespace net {
 

--- a/StrapperNet/lib/linux/TcpBasicSocket.cpp
+++ b/StrapperNet/lib/linux/TcpBasicSocket.cpp
@@ -154,6 +154,8 @@ void TcpBasicSocket::Close() noexcept
 
 void TcpBasicSocket::Write(void const* src, size_t len)
 {
+    if (!src)
+        throw ProgramError("Null pointer.");
     if (len == 0)
         throw ProgramError("Length must be greater than 0.");
 
@@ -171,6 +173,8 @@ bool TcpBasicSocket::Read(void* dest, size_t len)
 {
     try
     {
+        if (!dest)
+            throw ProgramError("Null pointer.");
         if (len == 0)
             throw ProgramError("Length must be greater than 0.");
         if (len > static_cast<size_t>(std::numeric_limits<ssize_t>::max()))

--- a/StrapperNet/lib/linux/TcpBasicSocket.cpp
+++ b/StrapperNet/lib/linux/TcpBasicSocket.cpp
@@ -25,7 +25,6 @@
 
 #include <cassert>
 #include <limits>
-#include <memory>
 
 namespace strapper { namespace net {
 

--- a/StrapperNet/lib/linux/UdpBasicSocket.cpp
+++ b/StrapperNet/lib/linux/UdpBasicSocket.cpp
@@ -101,6 +101,8 @@ void UdpBasicSocket::Close() noexcept
 
 void UdpBasicSocket::Write(void const* src, size_t len, IpAddressV4 const& ipAddress, uint16_t port)
 {
+    if (!src)
+        throw ProgramError("Null pointer.");
     if (len == 0)
         throw ProgramError("Length must be greater than 0.");
 
@@ -143,11 +145,13 @@ void UdpBasicSocket::Write(void const* src, size_t len, IpAddressV4 const& ipAdd
 
 unsigned UdpBasicSocket::Read(void* dest, size_t maxlen, IpAddressV4* out_ipAddress, uint16_t* out_port)
 {
-    sockaddr_in info{};
-    socklen_t infoLen = sizeof(info);
+    if (!dest)
+        throw ProgramError("Null pointer.");
     if (maxlen == 0)
         throw ProgramError("Max length must be greater than 0.");
 
+    sockaddr_in info{};
+    socklen_t infoLen = sizeof(info);
     ssize_t amountRead = 0;
     do
     {

--- a/StrapperNet/lib/windows/ErrorCode.cpp
+++ b/StrapperNet/lib/windows/ErrorCode.cpp
@@ -20,7 +20,6 @@
 #include <strapper/net/SocketError.h>
 
 #include <cassert>
-#include <string>
 
 namespace strapper { namespace net {
 

--- a/StrapperNet/lib/windows/TcpBasicListener.cpp
+++ b/StrapperNet/lib/windows/TcpBasicListener.cpp
@@ -20,7 +20,6 @@
 #include <strapper/net/SocketError.h>
 #include "SocketFd.h"
 
-#include <cassert>
 #include <memory>
 
 namespace strapper { namespace net {
@@ -49,7 +48,6 @@ SocketHandle Start(uint16_t port)
     }
 
     SocketHandle socket = SocketHandle(hostInfoList->ai_family, hostInfoList->ai_socktype, hostInfoList->ai_protocol);
-    assert(socket);
 
     /*
     BOOL const yes = true;

--- a/StrapperNet/lib/windows/TcpBasicSocket.cpp
+++ b/StrapperNet/lib/windows/TcpBasicSocket.cpp
@@ -20,9 +20,7 @@
 #include <strapper/net/SocketError.h>
 #include "SocketFd.h"
 
-#include <cassert>
 #include <limits>
-#include <memory>
 
 namespace strapper { namespace net {
 
@@ -52,7 +50,6 @@ SocketHandle Connect(std::string const& host, uint16_t port)
         throw ProgramError("getaddrinfo returned invalid length.");
 
     SocketHandle socket(hostInfoList->ai_family, hostInfoList->ai_socktype, hostInfoList->ai_protocol);
-    assert(socket);
 
     if (connect(**socket, hostInfoList->ai_addr, static_cast<int>(hostInfoList->ai_addrlen)) == SOCKET_ERROR)
         throw SocketError(WSAGetLastError());

--- a/StrapperNet/lib/windows/TcpBasicSocket.cpp
+++ b/StrapperNet/lib/windows/TcpBasicSocket.cpp
@@ -138,6 +138,8 @@ void TcpBasicSocket::Close() noexcept
 
 void TcpBasicSocket::Write(void const* src, size_t len)
 {
+    if (!src)
+        throw ProgramError("Null pointer.");
     if (len == 0)
         throw ProgramError("Length must be greater than 0.");
     if (len > static_cast<size_t>(std::numeric_limits<int>::max()))
@@ -154,6 +156,8 @@ bool TcpBasicSocket::Read(void* dest, size_t len)
 {
     try
     {
+        if (!dest)
+            throw ProgramError("Null pointer.");
         if (len == 0)
             throw ProgramError("Length must be greater than 0.");
         if (len > static_cast<size_t>(std::numeric_limits<int>::max()))

--- a/StrapperNet/lib/windows/UdpBasicSocket.cpp
+++ b/StrapperNet/lib/windows/UdpBasicSocket.cpp
@@ -100,6 +100,8 @@ void UdpBasicSocket::Close() noexcept
 
 void UdpBasicSocket::Write(void const* src, size_t len, IpAddressV4 const& ipAddress, uint16_t port)
 {
+    if (!src)
+        throw ProgramError("Null pointer.");
     if (len == 0)
         throw ProgramError("Length must be greater than 0.");
     if (len > static_cast<size_t>(std::numeric_limits<int>::max()))
@@ -171,13 +173,15 @@ void UdpBasicSocket::Write(void const* src, size_t len, IpAddressV4 const& ipAdd
 
 unsigned UdpBasicSocket::Read(void* dest, size_t maxlen, IpAddressV4* out_ipAddress, uint16_t* out_port)
 {
-    sockaddr_in info{};
-    int infoLen = sizeof(info);
+    if (!dest)
+        throw ProgramError("Null pointer.");
     if (maxlen == 0)
         throw ProgramError("Max length must be greater than 0.");
     if (maxlen > static_cast<size_t>(std::numeric_limits<int>::max()))
         throw ProgramError("Max length must be less than int max.");
 
+    sockaddr_in info{};
+    int infoLen = sizeof(info);
     int const amountRead = recvfrom(**m_socket,
                                     static_cast<char*>(dest),
                                     static_cast<int>(maxlen),

--- a/StrapperNet/lib/windows/UdpBasicSocket.cpp
+++ b/StrapperNet/lib/windows/UdpBasicSocket.cpp
@@ -20,7 +20,6 @@
 #include <strapper/net/SocketError.h>
 #include "SocketFd.h"
 
-#include <cassert>
 #include <limits>
 
 namespace strapper { namespace net {
@@ -31,7 +30,6 @@ namespace {
 SocketHandle MakeSocket(uint16_t myport)
 {
     SocketHandle socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    assert(socket);
 
     sockaddr_in myInfo{};
     myInfo.sin_family = AF_INET;

--- a/UnitTest/UnitTest/UnitTestProtocol.cpp
+++ b/UnitTest/UnitTest/UnitTestProtocol.cpp
@@ -285,7 +285,7 @@ TEST_F(UnitTestProtocol, ReadAfterShutdownTcpEc)
     ASSERT_EQ(m_sender.DataAvailable(&ec), 0u);
     ASSERT_FALSE(ec);
     // Note slight difference from previous tests. Test here with a null EC.
-    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), nullptr));
+    ASSERT_THROW(m_sender.Read(&c, sizeof(c), nullptr), SocketError);
     ASSERT_FALSE(m_sender);
     ASSERT_EQ(c, 0xAF);
 
@@ -301,24 +301,41 @@ TEST_F(UnitTestProtocol, ReadAfterShutdownTcpEc)
     ASSERT_FALSE(m_sender);
     ASSERT_EQ(c, 0xAF);
 
-    ASSERT_EQ(m_sender.DataAvailable(nullptr), 0u);
-    ASSERT_EQ(m_sender.DataAvailable(nullptr), 0u);
-    ASSERT_EQ(m_sender.DataAvailable(nullptr), 0u);
-    ASSERT_EQ(m_sender.DataAvailable(nullptr), 0u);
-    ASSERT_EQ(m_sender.DataAvailable(nullptr), 0u);
+    ASSERT_EQ(m_sender.DataAvailable(&ec), 0u);
+    ASSERT_TRUE(ec);
+    ec = ErrorCode();
+    ASSERT_EQ(m_sender.DataAvailable(&ec), 0u);
+    ASSERT_TRUE(ec);
+    ec = ErrorCode();
+    ASSERT_THROW(m_sender.DataAvailable(nullptr), ProgramError);
+    ASSERT_EQ(m_sender.DataAvailable(&ec), 0u);
+    ASSERT_TRUE(ec);
+    ec = ErrorCode();
+    ASSERT_EQ(m_sender.DataAvailable(&ec), 0u);
+    ASSERT_TRUE(ec);
+    ec = ErrorCode();
     ASSERT_EQ(m_sender.DataAvailable(&ec), 0u);
     ASSERT_TRUE(ec);
     ASSERT_THROW(ec.Rethrow(), ProgramError);
     ec = ErrorCode();
 
-    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), nullptr));
-    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), nullptr));
-    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), nullptr));
-    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), nullptr));
-    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), nullptr));
+    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), &ec));
+    ASSERT_TRUE(ec);
+    ec = ErrorCode();
+    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), &ec));
+    ASSERT_TRUE(ec);
+    ec = ErrorCode();
+    ASSERT_THROW(m_sender.Read(&c, sizeof(c), nullptr), ProgramError);
+    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), &ec));
+    ASSERT_TRUE(ec);
+    ec = ErrorCode();
+    ASSERT_FALSE(m_sender.Read(&c, sizeof(c), &ec));
+    ASSERT_TRUE(ec);
+    ec = ErrorCode();
     ASSERT_FALSE(m_sender.Read(&c, sizeof(c), &ec));
     ASSERT_TRUE(ec);
     ASSERT_THROW(ec.Rethrow(), ProgramError);
+    ec = ErrorCode();
 }
 
 }}}  // namespace strapper::net::test

--- a/UnitTest/UnitTest/UnitTestProtocol.cpp
+++ b/UnitTest/UnitTest/UnitTestProtocol.cpp
@@ -285,7 +285,7 @@ TEST_F(UnitTestProtocol, ReadAfterShutdownTcpEc)
     ASSERT_EQ(m_sender.DataAvailable(&ec), 0u);
     ASSERT_FALSE(ec);
     // Note slight difference from previous tests. Test here with a null EC.
-    ASSERT_THROW(m_sender.Read(&c, sizeof(c), nullptr), SocketError);
+    ASSERT_THROW(m_sender.Read(&c, sizeof(c), nullptr), ProgramError);
     ASSERT_FALSE(m_sender);
     ASSERT_EQ(c, 0xAF);
 


### PR DESCRIPTION
Combined EC-taking functions with non-EC functions in TcpSocket, UdpSocket, and TcpListener.
Added EC parameters to TcpSerializer.