### PR TITLE
Renamed TcpSocket IsConnected() to IsOpen()

### DIFF
--- a/StrapperNet/include/strapper/net/TcpBasicSocket.h
+++ b/StrapperNet/include/strapper/net/TcpBasicSocket.h
@@ -40,7 +40,7 @@ public:
     TcpBasicSocket& operator=(TcpBasicSocket&&) noexcept;  // = default
     ~TcpBasicSocket();
 
-    bool IsConnected() const;
+    bool IsOpen() const;
     void SetReadTimeout(unsigned milliseconds);
 
     void ShutdownSend();

--- a/StrapperNet/include/strapper/net/TcpSocket.h
+++ b/StrapperNet/include/strapper/net/TcpSocket.h
@@ -40,7 +40,7 @@ public:
 
     friend void swap(TcpSocket& left, TcpSocket& right);
 
-    bool IsConnected() const;
+    bool IsOpen() const;
     void SetReadTimeout(unsigned milliseconds, ErrorCode* ec = nullptr);
 
     void ShutdownSend(ErrorCode* ec = nullptr);

--- a/StrapperNet/lib/TcpSocket.cpp
+++ b/StrapperNet/lib/TcpSocket.cpp
@@ -84,7 +84,7 @@ void swap(TcpSocket& left, TcpSocket& right)
     swap(left.m_state, right.m_state);
 }
 
-bool TcpSocket::IsConnected() const
+bool TcpSocket::IsOpen() const
 {
     std::lock_guard<std::mutex> lock(m_socketLock);
     return m_state != State::CLOSED;
@@ -238,7 +238,7 @@ unsigned TcpSocket::DataAvailable(ErrorCode* ec /* = nullptr */)
 
 TcpSocket::operator bool() const
 {
-    return IsConnected();
+    return IsOpen();
 }
 
 bool TcpSocket::read(void* dest, size_t len)

--- a/StrapperNet/lib/linux/TcpBasicSocket.cpp
+++ b/StrapperNet/lib/linux/TcpBasicSocket.cpp
@@ -94,7 +94,7 @@ TcpBasicSocket::~TcpBasicSocket()
         Close();
 }
 
-bool TcpBasicSocket::IsConnected() const
+bool TcpBasicSocket::IsOpen() const
 {
     return !!m_socket;
 }
@@ -231,7 +231,7 @@ unsigned TcpBasicSocket::DataAvailable()
 
 TcpBasicSocket::operator bool() const
 {
-    return IsConnected();
+    return IsOpen();
 }
 
 }}  // namespace strapper::net

--- a/StrapperNet/lib/windows/TcpBasicSocket.cpp
+++ b/StrapperNet/lib/windows/TcpBasicSocket.cpp
@@ -83,7 +83,7 @@ TcpBasicSocket::~TcpBasicSocket()
         Close();
 }
 
-bool TcpBasicSocket::IsConnected() const
+bool TcpBasicSocket::IsOpen() const
 {
     return !!m_socket;
 }
@@ -201,7 +201,7 @@ unsigned TcpBasicSocket::DataAvailable()
 
 TcpBasicSocket::operator bool() const
 {
-    return IsConnected();
+    return IsOpen();
 }
 
 }}  // namespace strapper::net

--- a/UnitTest/UnitTest/UnitTestEndian.cpp
+++ b/UnitTest/UnitTest/UnitTestEndian.cpp
@@ -37,9 +37,9 @@ public:
         TcpListener listener(TestGlobals::port);
         ASSERT_TRUE(listener) << "Unable to start listener.";
         s_sender.reset(new TcpSerializer(TcpSocket(TestGlobals::localhost, TestGlobals::port)));
-        ASSERT_TRUE(s_sender->Socket().IsConnected()) << "Unable to connect client to listener.";
+        ASSERT_TRUE(s_sender->Socket().IsOpen()) << "Unable to connect client to listener.";
         s_receiver.reset(new TcpSerializer(TcpSocket(listener.Accept())));
-        ASSERT_TRUE(s_receiver->Socket().IsConnected()) << "Error on accept.";
+        ASSERT_TRUE(s_receiver->Socket().IsOpen()) << "Error on accept.";
     }
 
     static void TearDownTestSuite()
@@ -51,8 +51,8 @@ public:
     void SetUp() override
     {
         ASSERT_TRUE(s_sender);
-        ASSERT_TRUE(s_sender->Socket().IsConnected());
-        ASSERT_TRUE(s_receiver->Socket().IsConnected());
+        ASSERT_TRUE(s_sender->Socket().IsOpen());
+        ASSERT_TRUE(s_receiver->Socket().IsOpen());
         // Since the sockets are re-used, a previous test failure can leave some data in the buffer.
         ASSERT_EQ(s_receiver->Socket().DataAvailable(), 0u) << "Receiver had data in buffer before data was sent.";
     }

--- a/UnitTest/UnitTest/UnitTestError.cpp
+++ b/UnitTest/UnitTest/UnitTestError.cpp
@@ -52,7 +52,7 @@ public:
         m_sender = TcpSocket(TestGlobals::localhost, TestGlobals::port);
         ASSERT_TRUE(m_sender);
         m_receiver = listener.Accept();
-        ASSERT_TRUE(m_receiver.IsConnected());
+        ASSERT_TRUE(m_receiver.IsOpen());
         ASSERT_EQ(m_receiver.DataAvailable(), 0u);
     }
 
@@ -165,7 +165,7 @@ TEST_F(UnitTestError, UnblockReadTcp)
     });
 
     // Make sure the read is still blocking.
-    ASSERT_EQ(task.wait_for(milliseconds(200)), std::future_status::timeout) << (m_receiver.IsConnected() ? "Socket returned from read too early." : "Socket closed.");
+    ASSERT_EQ(task.wait_for(milliseconds(200)), std::future_status::timeout) << (m_receiver.IsOpen() ? "Socket returned from read too early." : "Socket closed.");
     std::this_thread::sleep_for(milliseconds(200));
     m_receiver.Close();  // This call should block until the operation is done.
     ASSERT_FALSE(m_receiver);
@@ -200,7 +200,7 @@ TEST_F(UnitTestError, UnblockReadTcpEc)
     });
 
     // Make sure the read is still blocking.
-    ASSERT_EQ(task.wait_for(milliseconds(200)), std::future_status::timeout) << (m_receiver.IsConnected() ? "Socket returned from read too early." : "Socket closed.");
+    ASSERT_EQ(task.wait_for(milliseconds(200)), std::future_status::timeout) << (m_receiver.IsOpen() ? "Socket returned from read too early." : "Socket closed.");
     std::this_thread::sleep_for(milliseconds(200));
     m_receiver.Close();  // This call should block until the operation is done.
     ASSERT_FALSE(m_receiver);

--- a/UnitTest/UnitTest/UnitTestProtocol.cpp
+++ b/UnitTest/UnitTest/UnitTestProtocol.cpp
@@ -52,7 +52,7 @@ public:
         m_sender = TcpSocket(TestGlobals::localhost, TestGlobals::port);
         ASSERT_TRUE(m_sender);
         m_receiver = listener.Accept();
-        ASSERT_TRUE(m_receiver.IsConnected());
+        ASSERT_TRUE(m_receiver.IsOpen());
         ASSERT_EQ(m_receiver.DataAvailable(), 0u);
     }
 

--- a/UnitTest/UnitTest/UnitTestSerialize.cpp
+++ b/UnitTest/UnitTest/UnitTestSerialize.cpp
@@ -40,9 +40,9 @@ public:
         TcpListener listener(TestGlobals::port);
         ASSERT_TRUE(listener) << "Unable to start listener.";
         s_sender.reset(new TcpSerializer(TcpSocket(TestGlobals::localhost, TestGlobals::port)));
-        ASSERT_TRUE(s_sender->Socket().IsConnected()) << "Unable to connect client to listener.";
+        ASSERT_TRUE(s_sender->Socket().IsOpen()) << "Unable to connect client to listener.";
         s_receiver.reset(new TcpSerializer(TcpSocket(listener.Accept())));
-        ASSERT_TRUE(s_receiver->Socket().IsConnected()) << "Error on accept.";
+        ASSERT_TRUE(s_receiver->Socket().IsOpen()) << "Error on accept.";
     }
 
     static void TearDownTestSuite()
@@ -54,8 +54,8 @@ public:
     void SetUp() override
     {
         ASSERT_TRUE(s_sender);
-        ASSERT_TRUE(s_sender->Socket().IsConnected());
-        ASSERT_TRUE(s_receiver->Socket().IsConnected());
+        ASSERT_TRUE(s_sender->Socket().IsOpen());
+        ASSERT_TRUE(s_receiver->Socket().IsOpen());
         // Since the sockets are re-used, a previous test failure can leave some data in the buffer.
         ASSERT_EQ(s_receiver->Socket().DataAvailable(), 0u) << "Receiver had data in buffer before data was sent.";
     }

--- a/UnitTest/UnitTest/UnitTestShutdown.cpp
+++ b/UnitTest/UnitTest/UnitTestShutdown.cpp
@@ -44,7 +44,7 @@ public:
         m_sender = TcpBasicSocket(TestGlobals::localhost, TestGlobals::port);
         ASSERT_TRUE(m_sender);
         m_receiver = listener.Accept();
-        ASSERT_TRUE(m_receiver.IsConnected());
+        ASSERT_TRUE(m_receiver.IsOpen());
         ASSERT_EQ(m_receiver.DataAvailable(), 0u);
     }
 

--- a/UnitTest/UnitTest/UnitTestSocket.cpp
+++ b/UnitTest/UnitTest/UnitTestSocket.cpp
@@ -47,9 +47,9 @@ TEST_F(UnitTestSocket, SelfConnectTcp)
     TcpListener listener(TestGlobals::port);
     ASSERT_TRUE(listener);
     TcpSocket client(TestGlobals::localhost, TestGlobals::port);
-    ASSERT_TRUE(client.IsConnected());
+    ASSERT_TRUE(client.IsOpen());
     TcpSocket host = listener.Accept();
-    ASSERT_TRUE(host.IsConnected());
+    ASSERT_TRUE(host.IsOpen());
 }
 
 TEST_F(UnitTestSocket, SelfConnectTcpEc)
@@ -61,11 +61,11 @@ TEST_F(UnitTestSocket, SelfConnectTcpEc)
     ASSERT_TRUE(listener);
     ASSERT_FALSE(ec);
     TcpSocket client(TestGlobals::localhost, TestGlobals::port, &ec);
-    ASSERT_TRUE(client.IsConnected());
+    ASSERT_TRUE(client.IsOpen());
     ASSERT_FALSE(ec);
     TcpSocket host = listener.Accept(&ec);
     ASSERT_FALSE(ec);
-    ASSERT_TRUE(host.IsConnected());
+    ASSERT_TRUE(host.IsOpen());
 }
 
 TEST_F(UnitTestSocket, CreateUdp)
@@ -98,9 +98,9 @@ TEST_F(UnitTestSocket, SendRecvBufTcp)
     TcpListener listener(TestGlobals::port);
     ASSERT_TRUE(listener);
     TcpSocket sender(TestGlobals::localhost, TestGlobals::port);
-    ASSERT_TRUE(sender.IsConnected());
+    ASSERT_TRUE(sender.IsOpen());
     TcpSocket receiver = listener.Accept();
-    ASSERT_TRUE(receiver.IsConnected());
+    ASSERT_TRUE(receiver.IsOpen());
 
     char sentData[6] = { 1, 2, 3, 4, 5, 6 };
     sender.Write(sentData, 5);
@@ -130,10 +130,10 @@ TEST_F(UnitTestSocket, SendRecvBufTcpEc)
     ASSERT_TRUE(listener);
     ASSERT_FALSE(ec);
     TcpSocket sender(TestGlobals::localhost, TestGlobals::port, &ec);
-    ASSERT_TRUE(sender.IsConnected());
+    ASSERT_TRUE(sender.IsOpen());
     ASSERT_FALSE(ec);
     TcpSocket receiver = listener.Accept(&ec);
-    ASSERT_TRUE(receiver.IsConnected());
+    ASSERT_TRUE(receiver.IsOpen());
     ASSERT_FALSE(ec);
 
     char sentData[6] = { 1, 2, 3, 4, 5, 6 };
@@ -272,9 +272,9 @@ TEST_F(UnitTestSocket, DataAvailableTcp)
     TcpListener listener(TestGlobals::port);
     ASSERT_TRUE(listener);
     TcpSerializer sender(TcpSocket(TestGlobals::localhost, TestGlobals::port));
-    ASSERT_TRUE(sender.Socket().IsConnected());
+    ASSERT_TRUE(sender.Socket().IsOpen());
     TcpSerializer receiver(TcpSocket(listener.Accept()));
-    ASSERT_TRUE(receiver.Socket().IsConnected());
+    ASSERT_TRUE(receiver.Socket().IsOpen());
 
     ASSERT_EQ(receiver.Socket().DataAvailable(), 0u);
 
@@ -297,10 +297,10 @@ TEST_F(UnitTestSocket, DataAvailableTcpEc)
     ASSERT_TRUE(listener);
     ASSERT_FALSE(ec);
     TcpSerializer sender(TcpSocket(TestGlobals::localhost, TestGlobals::port, &ec));
-    ASSERT_TRUE(sender.Socket().IsConnected());
+    ASSERT_TRUE(sender.Socket().IsOpen());
     ASSERT_FALSE(ec);
     TcpSerializer receiver(TcpSocket(listener.Accept(&ec)));
-    ASSERT_TRUE(receiver.Socket().IsConnected());
+    ASSERT_TRUE(receiver.Socket().IsOpen());
     ASSERT_FALSE(ec);
 
     ASSERT_EQ(receiver.Socket().DataAvailable(&ec), 0u);


### PR DESCRIPTION
"IsConnected" isn't accurate because the function returns true after the
connection has been ended, but before the socket is closed.