### PR TITLE
ci: fixed cppcheck in GitHub linting workflow

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -65,7 +65,7 @@ jobs:
         pip install -U pip
         pip install cpplint
         choco install llvm --version=14.0.3
-        choco install cppcheck
+        choco install cppcheck --version=2.7
         echo "$env:ProgramFiles\Cppcheck" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
Choco updated cppcheck to 2.8. It now requires a reboot.
Pinned cppcheck to 2.7.